### PR TITLE
Add Money Bots AI content automation workspace

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, Plai
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import IntegrityError
 from passlib.hash import bcrypt
 import httpx
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
@@ -23,6 +24,11 @@ NC_ADMIN_PASS = os.environ.get("NEXTCLOUD_ADMIN_PASS","admin")
 
 KUMA_URL = os.environ.get("KUMA_URL", "http://kuma:3001")
 KUMA_TOKEN = os.environ.get("KUMA_TOKEN", "")
+
+AI_MODEL = os.environ.get("AI_MODEL", "gpt-4o-mini")
+AI_API_BASE = os.environ.get("AI_API_BASE", "https://api.openai.com/v1")
+AI_API_KEY = os.environ.get("AI_API_KEY", "")
+AI_TIMEOUT = float(os.environ.get("AI_TIMEOUT", "45"))
 
 # ---------- DB ----------
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)
@@ -100,6 +106,30 @@ def init_db():
             customer_id INTEGER REFERENCES customers(id) ON DELETE CASCADE,
             PRIMARY KEY(node, vmid)
         );
+        CREATE TABLE IF NOT EXISTS ai_content_profiles(
+            id SERIAL PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            tone TEXT,
+            voice TEXT,
+            target_platform TEXT,
+            guidelines TEXT,
+            created_at TIMESTAMP DEFAULT NOW(),
+            updated_at TIMESTAMP DEFAULT NOW()
+        );
+        CREATE TABLE IF NOT EXISTS ai_content_jobs(
+            id SERIAL PRIMARY KEY,
+            profile_id INTEGER REFERENCES ai_content_profiles(id) ON DELETE SET NULL,
+            title TEXT NOT NULL,
+            keywords TEXT,
+            brief TEXT,
+            data_sources TEXT,
+            content_type TEXT,
+            generated_content TEXT,
+            status TEXT NOT NULL DEFAULT 'draft',
+            created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+            created_at TIMESTAMP DEFAULT NOW(),
+            updated_at TIMESTAMP DEFAULT NOW()
+        );
         """))
 init_db()
 
@@ -154,6 +184,117 @@ def audit(email: str, action: str, meta: dict):
     with engine.begin() as conn:
         conn.execute(text("INSERT INTO audit(actor_email,action,meta) VALUES (:e,:a,:m)"),
                      {"e":email, "a":action, "m":json.dumps(meta)})
+
+def ai_call(messages: List[dict]) -> Tuple[str, str, str]:
+    if not AI_API_KEY:
+        note = "AI provider is not configured. Set OPENAI_API_KEY to enable live generations."
+        return "needs_config", (
+            "[offline] AI automation is not configured yet. Provide OPENAI_API_KEY/AI_MODEL to enable live generations."
+        ), note
+    try:
+        url = AI_API_BASE.rstrip('/') + "/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {AI_API_KEY}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": AI_MODEL,
+            "messages": messages,
+            "temperature": 0.65,
+        }
+        resp = httpx.post(url, headers=headers, json=payload, timeout=AI_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        choices = data.get("choices") or []
+        if not choices:
+            raise HTTPException(502, "AI provider returned no completions")
+        content = choices[0].get("message", {}).get("content", "").strip()
+        if not content:
+            raise HTTPException(502, "AI provider returned empty content")
+        note = f"Generated via {AI_MODEL}"
+        return "ready", content, note
+    except httpx.HTTPStatusError as e:
+        print(f"[AI ERROR] status {e.response.status_code}: {e.response.text[:200]}", file=sys.stderr)
+        raise HTTPException(502, "AI provider error")
+    except httpx.HTTPError as e:
+        print(f"[AI ERROR] http {e}", file=sys.stderr)
+        raise HTTPException(502, "AI request failed")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[AI ERROR] unexpected {e}", file=sys.stderr)
+        raise HTTPException(500, "AI request failed")
+
+def format_profile(row) -> dict:
+    return {
+        "id": row.id,
+        "name": row.name,
+        "tone": row.tone or "",
+        "voice": row.voice or "",
+        "target_platform": row.target_platform or "",
+        "guidelines": row.guidelines or "",
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+def format_job(row) -> dict:
+    return {
+        "id": row.id,
+        "profile_id": row.profile_id,
+        "profile_name": row.profile_name or "",
+        "title": row.title,
+        "keywords": row.keywords or "",
+        "brief": row.brief or "",
+        "data_sources": row.data_sources or "",
+        "content_type": row.content_type or "",
+        "generated_content": row.generated_content or "",
+        "status": row.status,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+CONTENT_BLUEPRINTS = {
+    "social-post": "Craft a set of 3 platform-ready social media posts (TikTok, Instagram Reels, Twitter/X). Each should have a hook, supporting body, and CTA. Include relevant hashtags.",
+    "reddit-story": "Write a first-person Reddit-style storytelling post with a captivating title, clear conflict, and satisfying resolution. Keep it authentic and emotionally engaging.",
+    "video-script": "Develop a short-form video script with sections: Hook, Scene Beats, Voiceover, On-screen text, CTA. Keep pacing fast and visual cues clear.",
+}
+
+def build_ai_messages(profile: dict, title: str, content_type: str, keywords: str, brief: str, data_sources: str, extra: str) -> List[dict]:
+    system = (
+        "You are an elite content automation assistant specialized in creating viral, monetizable narratives. "
+        "Always respect the provided tone, target platform, and brand voice. Ensure outputs are ready to copy/paste."
+    )
+    tone_line = f"Preferred tone: {profile['tone']}" if profile.get("tone") else ""
+    voice_line = f"Voice: {profile['voice']}" if profile.get("voice") else ""
+    platform_line = f"Target platform(s): {profile['target_platform']}" if profile.get("target_platform") else ""
+    guidelines = profile.get("guidelines") or ""
+    blueprint = CONTENT_BLUEPRINTS.get(content_type, "Deliver a polished narrative optimized for engagement and monetization.")
+    user_prompt = f"""
+Project Title: {title}
+Content focus: {blueprint}
+
+Keywords / SEO focus: {keywords or 'n/a'}
+Creative brief:
+{brief or '(none)'}
+
+Supporting data sources or context:
+{data_sources or '(none)'}
+
+Additional operator instructions:
+{extra or '(none)'}
+
+Deliver the final asset in Markdown. Provide:
+- A punchy title or hook
+- Main body content according to the content focus
+- Three platform-specific captions with hashtags
+- Suggested visual or audio cues when relevant
+- Monetization or CTA ideas at the end
+"""
+    sys_msg = "\n".join([line for line in [system, tone_line, voice_line, platform_line, guidelines] if line])
+    return [
+        {"role": "system", "content": sys_msg},
+        {"role": "user", "content": user_prompt.strip()},
+    ]
 
 # ---------- Bootstrap users ----------
 @app.post("/admin/init")
@@ -245,6 +386,231 @@ def add_note(req: Request, payload: dict):
         conn.execute(text("INSERT INTO notes(user_id,content) VALUES (:uid,:c)"),{"uid":uid,"c":content})
     audit(email, "note", {"content": content[:120]})
     return {"ok": True}
+
+# ---------- Money Bots (AI Content) ----------
+@app.get("/ui/ai-content", response_class=HTMLResponse)
+def ui_ai_content(req: Request):
+    uid, email, role = require_user(req)
+    return render("ai_content.html", email=email)
+
+@app.get("/ai/profiles")
+def ai_profiles(req: Request):
+    _uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        rows = conn.execute(text(
+            """
+            SELECT id, name, tone, voice, target_platform, guidelines,
+                   TO_CHAR(created_at,'YYYY-MM-DD HH24:MI') AS created_at,
+                   TO_CHAR(updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
+            FROM ai_content_profiles
+            ORDER BY ai_content_profiles.updated_at DESC, ai_content_profiles.id DESC
+            LIMIT 200
+            """
+        )).fetchall()
+    return {"profiles": [format_profile(r) for r in rows]}
+
+@app.post("/ai/profiles")
+def ai_profile_create(req: Request, payload: dict):
+    uid, email, role = require_user(req)
+    name = (payload.get("name") or "").strip()
+    if not name:
+        raise HTTPException(400, "profile name required")
+    tone = (payload.get("tone") or "").strip()
+    voice = (payload.get("voice") or "").strip()
+    target = (payload.get("target_platform") or "").strip()
+    guidelines = (payload.get("guidelines") or "").strip()
+    with engine.begin() as conn:
+        try:
+            row = conn.execute(text(
+                """
+                INSERT INTO ai_content_profiles(name,tone,voice,target_platform,guidelines)
+                VALUES (:name,:tone,:voice,:target,:guidelines)
+                RETURNING id,name,tone,voice,target_platform,guidelines,
+                          TO_CHAR(created_at,'YYYY-MM-DD HH24:MI') AS created_at,
+                          TO_CHAR(updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
+                """
+            ), {
+                "name": name,
+                "tone": tone,
+                "voice": voice,
+                "target": target,
+                "guidelines": guidelines,
+            }).fetchone()
+        except IntegrityError:
+            raise HTTPException(409, "profile name already exists")
+    audit(email, "ai:profile:create", {"profile": name})
+    return {"profile": format_profile(row)}
+
+@app.put("/ai/profiles/{profile_id}")
+def ai_profile_update(req: Request, profile_id: int, payload: dict):
+    uid, email, role = require_user(req)
+    name = (payload.get("name") or "").strip()
+    if not name:
+        raise HTTPException(400, "profile name required")
+    tone = (payload.get("tone") or "").strip()
+    voice = (payload.get("voice") or "").strip()
+    target = (payload.get("target_platform") or "").strip()
+    guidelines = (payload.get("guidelines") or "").strip()
+    with engine.begin() as conn:
+        try:
+            row = conn.execute(text(
+                """
+                UPDATE ai_content_profiles
+                SET name=:name, tone=:tone, voice=:voice, target_platform=:target,
+                    guidelines=:guidelines, updated_at=NOW()
+                WHERE id=:id
+                RETURNING id,name,tone,voice,target_platform,guidelines,
+                          TO_CHAR(created_at,'YYYY-MM-DD HH24:MI') AS created_at,
+                          TO_CHAR(updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
+                """
+            ), {
+                "id": profile_id,
+                "name": name,
+                "tone": tone,
+                "voice": voice,
+                "target": target,
+                "guidelines": guidelines,
+            }).fetchone()
+        except IntegrityError:
+            raise HTTPException(409, "profile name already exists")
+    if not row:
+        raise HTTPException(404, "profile not found")
+    audit(email, "ai:profile:update", {"profile_id": profile_id})
+    return {"profile": format_profile(row)}
+
+@app.delete("/ai/profiles/{profile_id}")
+def ai_profile_delete(req: Request, profile_id: int):
+    uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        res = conn.execute(text("DELETE FROM ai_content_profiles WHERE id=:id"), {"id": profile_id})
+    if res.rowcount == 0:
+        raise HTTPException(404, "profile not found")
+    audit(email, "ai:profile:delete", {"profile_id": profile_id})
+    return {"ok": True}
+
+@app.get("/ai/jobs")
+def ai_jobs(req: Request, profile_id: Optional[int] = Query(None), limit: int = Query(20, ge=1, le=100)):
+    _uid, email, role = require_user(req)
+    base_sql = (
+        "SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords, j.brief, j.data_sources, "
+        "j.content_type, j.generated_content, j.status, "
+        "TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at, TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at "
+        "FROM ai_content_jobs j LEFT JOIN ai_content_profiles p ON p.id=j.profile_id"
+    )
+    params = {"limit": limit}
+    if profile_id:
+        base_sql += " WHERE j.profile_id=:pid"
+        params["pid"] = profile_id
+    base_sql += " ORDER BY j.updated_at DESC, j.id DESC LIMIT :limit"
+    with engine.begin() as conn:
+        rows = conn.execute(text(base_sql), params).fetchall()
+    return {"jobs": [format_job(r) for r in rows]}
+
+@app.get("/ai/jobs/{job_id}")
+def ai_job_detail(req: Request, job_id: int):
+    _uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        row = conn.execute(text(
+            """
+            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords,
+                   j.brief, j.data_sources, j.content_type, j.generated_content, j.status,
+                   TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at,
+                   TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
+            FROM ai_content_jobs j LEFT JOIN ai_content_profiles p ON p.id=j.profile_id
+            WHERE j.id=:id
+            """
+        ), {"id": job_id}).fetchone()
+    if not row:
+        raise HTTPException(404, "job not found")
+    return {"job": format_job(row)}
+
+@app.delete("/ai/jobs/{job_id}")
+def ai_job_delete(req: Request, job_id: int):
+    uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        res = conn.execute(text("DELETE FROM ai_content_jobs WHERE id=:id"), {"id": job_id})
+    if res.rowcount == 0:
+        raise HTTPException(404, "job not found")
+    audit(email, "ai:job:delete", {"job_id": job_id})
+    return {"ok": True}
+
+@app.post("/ai/content")
+def ai_generate(req: Request, payload: dict):
+    uid, email, role = require_user(req)
+    try:
+        profile_id = int(payload.get("profile_id")) if payload.get("profile_id") else None
+    except (TypeError, ValueError):
+        raise HTTPException(400, "invalid profile id")
+    title = (payload.get("title") or "").strip()
+    if not title:
+        raise HTTPException(400, "title required")
+    content_type = (payload.get("content_type") or "social-post").strip() or "social-post"
+    keywords = payload.get("keywords")
+    if isinstance(keywords, list):
+        keywords = ", ".join([str(k).strip() for k in keywords if str(k).strip()])
+    else:
+        keywords = (keywords or "").strip()
+    brief = (payload.get("brief") or "").strip()
+    data_sources = (payload.get("data_sources") or "").strip()
+    extra = (payload.get("extra") or "").strip()
+    with engine.begin() as conn:
+        profile_row = None
+        if profile_id:
+            profile_row = conn.execute(text(
+                "SELECT id, name, tone, voice, target_platform, guidelines FROM ai_content_profiles WHERE id=:id"
+            ), {"id": profile_id}).fetchone()
+            if not profile_row:
+                raise HTTPException(404, "profile not found")
+        profile_dict = {
+            "tone": profile_row.tone if profile_row else payload.get("tone", ""),
+            "voice": profile_row.voice if profile_row else payload.get("voice", ""),
+            "target_platform": profile_row.target_platform if profile_row else payload.get("target_platform", ""),
+            "guidelines": profile_row.guidelines if profile_row else payload.get("guidelines", ""),
+            "name": profile_row.name if profile_row else payload.get("profile_label", ""),
+        }
+        inserted = conn.execute(text(
+            """
+            INSERT INTO ai_content_jobs(profile_id,title,keywords,brief,data_sources,content_type,status,created_by)
+            VALUES (:pid,:title,:keywords,:brief,:data_sources,:ctype,'pending',:uid)
+            RETURNING id
+            """
+        ), {
+            "pid": profile_id,
+            "title": title,
+            "keywords": keywords,
+            "brief": brief,
+            "data_sources": data_sources,
+            "ctype": content_type,
+            "uid": uid,
+        }).fetchone()
+        job_id = inserted.id
+    messages = build_ai_messages(profile_dict, title, content_type, keywords, brief, data_sources, extra)
+    try:
+        status, generated, note = ai_call(messages)
+    except HTTPException as he:
+        with engine.begin() as conn:
+            conn.execute(text(
+                "UPDATE ai_content_jobs SET status='error', generated_content=:msg, updated_at=NOW() WHERE id=:id"
+            ), {"id": job_id, "msg": f"Generation failed: {he.detail}"})
+        raise
+    with engine.begin() as conn:
+        conn.execute(text(
+            "UPDATE ai_content_jobs SET generated_content=:content, status=:status, updated_at=NOW() WHERE id=:id"
+        ), {"id": job_id, "content": generated, "status": status})
+        row = conn.execute(text(
+            """
+            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords,
+                   j.brief, j.data_sources, j.content_type, j.generated_content, j.status,
+                   TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at,
+                   TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
+            FROM ai_content_jobs j LEFT JOIN ai_content_profiles p ON p.id=j.profile_id
+            WHERE j.id=:id
+            """
+        ), {"id": job_id}).fetchone()
+    if not row:
+        raise HTTPException(500, "job retrieval failed")
+    audit(email, "ai:generate", {"job_id": job_id, "title": title, "profile": profile_dict.get("name")})
+    return {"job": format_job(row), "note": note}
 
 # ---------- Proxmox helpers ----------
 def pve_headers():

--- a/backend/app/templates/ai_content.html
+++ b/backend/app/templates/ai_content.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Money Bots · AI Content Lab</title>
+  <style>
+    body{font-family:system-ui;background:#0b0f14;color:#e8edf5;margin:0}
+    .wrap{padding:18px;max-width:1160px;margin:0 auto}
+    h1,h2,h3{margin:0 0 12px}
+    .muted{color:#94a3b8;font-size:0.92rem}
+    .grid{display:grid;gap:16px;margin-top:18px}
+    .two{grid-template-columns:repeat(auto-fit,minmax(320px,1fr))}
+    .panel{background:#111923;border-radius:14px;padding:18px;box-shadow:0 0 0 1px #1e2633}
+    label{display:block;font-size:0.85rem;margin-top:8px;margin-bottom:4px;color:#9fb3d3}
+    input,textarea,select{width:100%;background:#0e141d;color:#f1f5f9;border:1px solid #1f2937;border-radius:10px;padding:9px;font-size:0.95rem}
+    textarea{min-height:96px;resize:vertical}
+    button{background:#2563eb;color:#fff;border:none;border-radius:10px;padding:9px 16px;margin-top:12px;font-size:0.95rem;cursor:pointer;transition:background .2s}
+    button:hover{background:#1d4ed8}
+    button.secondary{background:#1f2937}
+    button.secondary:hover{background:#111827}
+    .flex{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+    .chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
+    .chip{background:#1e293b;padding:4px 8px;border-radius:999px;font-size:0.8rem}
+    .profile-card{padding:14px;background:#0f172a;border-radius:12px;border:1px solid #1f2a3a;margin-top:12px}
+    .profile-card header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+    .status{display:inline-flex;align-items:center;gap:6px;font-size:0.85rem}
+    .status.ready{color:#4ade80}
+    .status.needs_config{color:#facc15}
+    .status.error{color:#f87171}
+    .job{background:#0f172a;border-radius:12px;border:1px solid #1f2a3a;padding:14px;margin-top:12px}
+    pre{white-space:pre-wrap;word-wrap:break-word;background:#0b1220;border-radius:12px;padding:12px;margin-top:12px;font-size:0.9rem}
+    .list-header{display:flex;justify-content:space-between;align-items:center}
+    .small{font-size:0.8rem;color:#94a3b8}
+    .actions button{margin-right:8px}
+    .inline{display:inline-flex;gap:8px;align-items:center}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Money Making Bots</h1>
+    <p class="muted">Build reusable voices and spin up social content, Reddit-style stories, or short-form video scripts on demand. Profiles capture tone, voice, and platform targets so every drop stays on-brand.</p>
+
+    <div class="grid two">
+      <section class="panel">
+        <h3>1 · Save a creator profile</h3>
+        <form id="profileForm">
+          <label for="profile_name">Profile name</label>
+          <input id="profile_name" placeholder="e.g. TikTok Storyteller" required>
+
+          <label for="profile_tone">Tone / energy</label>
+          <input id="profile_tone" placeholder="upbeat, witty, cinematic">
+
+          <label for="profile_voice">Voice description</label>
+          <input id="profile_voice" placeholder="first-person gamer, mentor, narrator">
+
+          <label for="profile_platform">Primary platforms</label>
+          <input id="profile_platform" placeholder="TikTok · Instagram Reels · Reddit">
+
+          <label for="profile_rules">Guidelines / mandatory beats</label>
+          <textarea id="profile_rules" placeholder="Key selling points, compliance notes, structure cues"></textarea>
+
+          <button type="submit">Save profile</button>
+        </form>
+        <div id="profilesEmpty" class="muted" style="margin-top:12px;display:none">No profiles yet. Start by saving one.</div>
+        <div id="profilesList"></div>
+      </section>
+
+      <section class="panel">
+        <h3>2 · Generate content</h3>
+        <form id="generationForm">
+          <label for="gen_profile">Profile</label>
+          <select id="gen_profile"></select>
+
+          <label for="gen_type">Content type</label>
+          <select id="gen_type">
+            <option value="social-post">Social media drop (3 posts)</option>
+            <option value="reddit-story">Reddit farm story</option>
+            <option value="video-script">Short-form video script</option>
+          </select>
+
+          <label for="gen_title">Campaign title / hook</label>
+          <input id="gen_title" placeholder="Farmed horror win in Apex Legends" required>
+
+          <label for="gen_keywords">Keywords (comma separated)</label>
+          <input id="gen_keywords" placeholder="gaming, apex legends, horror twist">
+
+          <label for="gen_brief">Creative brief</label>
+          <textarea id="gen_brief" placeholder="What should this piece accomplish?"></textarea>
+
+          <label for="gen_sources">Data feeds / references</label>
+          <textarea id="gen_sources" placeholder="Links, stats, existing docs"></textarea>
+
+          <label for="gen_extra">Extra operator notes</label>
+          <textarea id="gen_extra" placeholder="Add twists, monetization angles, CTA specifics"></textarea>
+
+          <div class="flex">
+            <button type="submit">Generate</button>
+            <button type="button" class="secondary" onclick="copyOutput()">Copy output</button>
+            <span id="aiStatus" class="muted"></span>
+          </div>
+        </form>
+        <pre id="gen_output" style="display:none"></pre>
+      </section>
+    </div>
+
+    <section class="panel" style="margin-top:18px">
+      <div class="list-header">
+        <h3>3 · Recent automation runs</h3>
+        <button type="button" class="secondary" onclick="refreshJobs()">Refresh</button>
+      </div>
+      <div id="jobsEmpty" class="muted" style="margin-top:12px;display:none">No generations yet. Launch one above.</div>
+      <div id="jobsList"></div>
+    </section>
+  </div>
+  <script>
+    const esc = (value) => String(value ?? '').replace(/[&<>]/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[ch]));
+    let profiles = [];
+    let jobs = [];
+    const profileSelect = document.getElementById('gen_profile');
+    profileSelect.innerHTML = '<option value="">(loading profiles...)</option>';
+
+    async function fetchJSON(url, options) {
+      const res = await fetch(url, options);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || (res.status + ' ' + res.statusText));
+      }
+      return await res.json();
+    }
+
+    async function loadProfiles() {
+      try {
+        const data = await fetchJSON('/ai/profiles');
+        profiles = data.profiles || [];
+        renderProfiles();
+      } catch (err) {
+        console.error('Profiles load failed', err);
+        document.getElementById('profilesEmpty').style.display = 'block';
+        document.getElementById('profilesEmpty').textContent = 'Failed to load profiles: ' + err.message;
+      }
+    }
+
+    function renderProfiles() {
+      const wrap = document.getElementById('profilesList');
+      wrap.innerHTML = '';
+      const empty = document.getElementById('profilesEmpty');
+      if (!profiles.length) {
+        empty.style.display = 'block';
+        if (!document.getElementById('gen_profile').value) {
+          document.getElementById('gen_profile').innerHTML = '<option value="">(no saved profiles)</option>';
+        }
+        return;
+      }
+      empty.style.display = 'none';
+      const select = document.getElementById('gen_profile');
+      const previous = select.value;
+      select.innerHTML = '<option value="">Custom prompt (no saved profile)</option>' + profiles.map(p => `<option value="${p.id}">${esc(p.name)}</option>`).join('');
+      if (previous && profiles.some(p => String(p.id) === previous)) {
+        select.value = previous;
+      } else if (profiles.length) {
+        select.value = profiles[0].id;
+      }
+      profiles.forEach((p) => {
+        const card = document.createElement('div');
+        card.className = 'profile-card';
+        const pid = JSON.stringify(p.id);
+        card.innerHTML = `
+          <header>
+            <div>
+              <strong>${esc(p.name)}</strong><div class="small">Updated ${esc(p.updated_at || '')}</div>
+            </div>
+            <div class="actions">
+              <button class="secondary" type="button" onclick="prefillProfile(${pid})">Load</button>
+              <button class="secondary" type="button" onclick="removeProfile(${pid})">Delete</button>
+            </div>
+          </header>
+          <div class="small">Tone: ${esc(p.tone || '—')}</div>
+          <div class="small">Voice: ${esc(p.voice || '—')}</div>
+          <div class="small">Platforms: ${esc(p.target_platform || '—')}</div>
+          <div class="small" style="margin-top:6px">Guidelines:<br>${esc(p.guidelines || '—')}</div>
+        `;
+        wrap.appendChild(card);
+      });
+    }
+
+    async function saveProfile(event) {
+      event.preventDefault();
+      const payload = {
+        name: document.getElementById('profile_name').value.trim(),
+        tone: document.getElementById('profile_tone').value.trim(),
+        voice: document.getElementById('profile_voice').value.trim(),
+        target_platform: document.getElementById('profile_platform').value.trim(),
+        guidelines: document.getElementById('profile_rules').value.trim(),
+      };
+      if (!payload.name) {
+        alert('Profile name is required');
+        return;
+      }
+      try {
+        await fetchJSON('/ai/profiles', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(payload),
+        });
+        document.getElementById('profileForm').reset();
+        loadProfiles();
+      } catch (err) {
+        alert('Save failed: ' + err.message);
+      }
+    }
+
+    function prefillProfile(id) {
+      const target = Number(id);
+      const p = profiles.find((x) => Number(x.id) === target);
+      if (!p) return;
+      document.getElementById('profile_name').value = p.name;
+      document.getElementById('profile_tone').value = p.tone;
+      document.getElementById('profile_voice').value = p.voice;
+      document.getElementById('profile_platform').value = p.target_platform;
+      document.getElementById('profile_rules').value = p.guidelines;
+      document.getElementById('gen_profile').value = String(p.id);
+    }
+
+    async function removeProfile(id) {
+      if (!confirm('Delete this profile?')) return;
+      const target = Number(id);
+      try {
+        await fetchJSON(`/ai/profiles/${target}`, { method: 'DELETE' });
+        if (Number(document.getElementById('gen_profile').value) === target) {
+          document.getElementById('gen_profile').value = '';
+        }
+        loadProfiles();
+      } catch (err) {
+        alert('Delete failed: ' + err.message);
+      }
+    }
+
+    async function runGeneration(event) {
+      event.preventDefault();
+      const payload = {
+        profile_id: document.getElementById('gen_profile').value || null,
+        content_type: document.getElementById('gen_type').value,
+        title: document.getElementById('gen_title').value.trim(),
+        keywords: document.getElementById('gen_keywords').value.trim(),
+        brief: document.getElementById('gen_brief').value.trim(),
+        data_sources: document.getElementById('gen_sources').value.trim(),
+        extra: document.getElementById('gen_extra').value.trim(),
+      };
+      if (!payload.title) {
+        alert('Title is required');
+        return;
+      }
+      setStatus('Generating...');
+      try {
+        const data = await fetchJSON('/ai/content', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(payload),
+        });
+        const job = data.job;
+        const out = document.getElementById('gen_output');
+        out.style.display = 'block';
+        out.textContent = job.generated_content || '[no content returned]';
+        setStatus(data.note || `Status: ${job.status}`);
+        refreshJobs();
+      } catch (err) {
+        setStatus('Error: ' + err.message);
+        const out = document.getElementById('gen_output');
+        out.style.display = 'block';
+        out.textContent = 'Generation failed: ' + err.message;
+      }
+    }
+
+    async function refreshJobs() {
+      try {
+        const data = await fetchJSON('/ai/jobs');
+        jobs = data.jobs || [];
+        renderJobs();
+      } catch (err) {
+        console.error('Jobs load failed', err);
+        const empty = document.getElementById('jobsEmpty');
+        empty.style.display = 'block';
+        empty.textContent = 'Failed to load jobs: ' + err.message;
+      }
+    }
+
+    function renderJobs() {
+      const wrap = document.getElementById('jobsList');
+      wrap.innerHTML = '';
+      const empty = document.getElementById('jobsEmpty');
+      if (!jobs.length) {
+        empty.style.display = 'block';
+        return;
+      }
+      empty.style.display = 'none';
+      jobs.forEach((j) => {
+        const div = document.createElement('div');
+        div.className = 'job';
+        div.innerHTML = `
+          <div class="inline">
+            <strong>${esc(j.title)}</strong>
+            <span class="chip">${esc(j.content_type || 'custom')}</span>
+          </div>
+          <div class="small">Profile: ${esc(j.profile_name || 'custom prompt')}</div>
+          <div class="small">Ran ${esc(j.updated_at || j.created_at || '')}</div>
+          <div class="status ${esc(j.status)}">Status: ${esc(j.status)}</div>
+          <div class="small" style="margin-top:8px">Keywords: ${esc(j.keywords || '—')}</div>
+          <details style="margin-top:10px">
+            <summary class="small">View output</summary>
+            <pre>${esc(j.generated_content || '')}</pre>
+          </details>
+        `;
+        wrap.appendChild(div);
+      });
+    }
+
+    function setStatus(msg) {
+      document.getElementById('aiStatus').textContent = msg || '';
+    }
+
+    function copyOutput() {
+      const text = document.getElementById('gen_output').textContent;
+      if (!text) {
+        alert('Nothing to copy yet.');
+        return;
+      }
+      navigator.clipboard.writeText(text).then(() => setStatus('Copied to clipboard'), (err) => setStatus('Copy failed: ' + err));
+    }
+
+    document.getElementById('profileForm').addEventListener('submit', saveProfile);
+    document.getElementById('generationForm').addEventListener('submit', runGeneration);
+
+    loadProfiles();
+    refreshJobs();
+  </script>
+</body>
+</html>

--- a/dashy/conf.yml
+++ b/dashy/conf.yml
@@ -37,6 +37,12 @@ sections:
       - type: iframe
         options: { url: http://backend.liork.cloud/ui/services, height: 760 }
 
+  - name: Money Bots
+    icon: fas fa-robot
+    widgets:
+      - type: iframe
+        options: { url: http://backend.liork.cloud/ui/ai-content, height: 760 }
+
   - name: Files & Tasks
     icon: fas fa-folder-tree
     items:

--- a/docs/money_bots.md
+++ b/docs/money_bots.md
@@ -1,0 +1,47 @@
+# Money Making Bots Content Automation
+
+The Money Bots unit adds an AI-assisted workspace for spinning up social posts, Reddit-style narratives, and short-form video scripts. It lives at `/ui/ai-content` inside the backend and is also embedded in Dashy via the **Money Bots** section.
+
+## Key concepts
+
+- **Profiles** capture reusable tone, voice, platform focus, and guardrails. Operators can create, update, and delete them via the UI or `/ai/profiles` endpoints.
+- **Jobs** log every generation run with metadata, generated copy, and current status. They can be queried with `/ai/jobs`.
+- **Generations** call the configured chat completion provider to produce Markdown output that includes hooks, body, captions, and monetization prompts.
+
+## API surface
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/ai/profiles` | GET | List saved content profiles. |
+| `/ai/profiles` | POST | Create a new profile. |
+| `/ai/profiles/{id}` | PUT | Update an existing profile. |
+| `/ai/profiles/{id}` | DELETE | Remove a profile. |
+| `/ai/jobs` | GET | List recent generation jobs (optionally filtered by `profile_id`). |
+| `/ai/jobs/{id}` | GET | Retrieve job details. |
+| `/ai/jobs/{id}` | DELETE | Delete a job log entry. |
+| `/ai/content` | POST | Trigger a new generation run. |
+
+## Environment variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `AI_MODEL` | Model name for chat completions. | `gpt-4o-mini` |
+| `AI_API_BASE` | Base URL for the chat completions endpoint. | `https://api.openai.com/v1` |
+| `AI_API_KEY` | API key/token for the AI provider. | _empty_ |
+| `AI_TIMEOUT` | Timeout in seconds for the AI call. | `45` |
+
+If `AI_API_KEY` is not set, the backend stores a placeholder result and returns status `needs_config` so operators know configuration is required.
+
+## Prompt design
+
+Generations combine:
+
+- The selected profile’s tone, voice, target platform, and guardrails.
+- A content blueprint (social posts, Reddit story, or video script) that dictates structure.
+- Operator-supplied keywords, briefs, and data sources.
+
+Outputs are returned in Markdown with a hook, main body, platform captions, visual cues, and monetization ideas ready for post-processing or publishing.
+
+## Audit trail
+
+Profile changes, job deletions, and content runs are logged to the existing audit table so leadership can review usage.


### PR DESCRIPTION
## Summary
- add AI configuration, persistence tables, and REST endpoints to drive the Money Bots content automation service
- build a Money Bots UI for managing creator profiles and triggering AI content runs, and surface it inside Dashy
- document configuration, API surface, and operating guidance for the new automation unit

## Testing
- python -m compileall backend/app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d8809f7fbc8326b1e10da647c4a3f3