### PR TITLE
Add AI content scheduler UI and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ are documented in [`docs/deploy_vm_192.168.1.22.md`](docs/deploy_vm_192.168.1.22
 Money Bots profiles and automation capabilities are covered in
 [`docs/money_bots.md`](docs/money_bots.md). The Dashy tile opens the same UI at
 `/ui/ai-content`, letting you create, edit, and trigger content jobs from the
-dashboard once the backend is up.
+dashboard once the backend is up. The same view now includes a publishing
+schedule board so operators can review upcoming drops and reschedule or cancel
+them without leaving the automation workspace.
 
 ## Additional documentation
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import os, time, base64, hmac, hashlib, json, sys, traceback
+from datetime import datetime, timezone
 from typing import Optional, List, Tuple
 from fastapi import FastAPI, HTTPException, Request, Form, Query
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, PlainTextResponse
@@ -130,6 +131,18 @@ def init_db():
             created_at TIMESTAMP DEFAULT NOW(),
             updated_at TIMESTAMP DEFAULT NOW()
         );
+        CREATE TABLE IF NOT EXISTS ai_content_schedules(
+            id SERIAL PRIMARY KEY,
+            job_id INTEGER REFERENCES ai_content_jobs(id) ON DELETE CASCADE,
+            platform TEXT NOT NULL,
+            scheduled_for TIMESTAMP NOT NULL,
+            status TEXT NOT NULL DEFAULT 'scheduled',
+            created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+            last_attempted_at TIMESTAMP,
+            result TEXT,
+            created_at TIMESTAMP DEFAULT NOW(),
+            updated_at TIMESTAMP DEFAULT NOW()
+        );
         """))
 init_db()
 
@@ -193,7 +206,6 @@ def ai_call(messages: List[dict]) -> Tuple[str, str, str]:
             "[offline] AI automation is not configured yet. Provide OPENAI_API_KEY/AI_MODEL to enable live generations.",
             note,
         )
-main
     try:
         url = AI_API_BASE.rstrip('/') + "/chat/completions"
         headers = {
@@ -245,6 +257,7 @@ def format_job(row) -> dict:
         "id": row.id,
         "profile_id": row.profile_id,
         "profile_name": row.profile_name or "",
+        "profile_platform": getattr(row, "profile_platform", "") or "",
         "title": row.title,
         "keywords": row.keywords or "",
         "brief": row.brief or "",
@@ -255,6 +268,68 @@ def format_job(row) -> dict:
         "created_at": row.created_at,
         "updated_at": row.updated_at,
     }
+
+SCHEDULE_COLUMNS = """
+    s.id,
+    s.job_id,
+    j.title AS job_title,
+    j.content_type AS job_content_type,
+    COALESCE(p.name, '') AS job_profile_name,
+    COALESCE(p.target_platform, '') AS job_profile_platform,
+    s.platform,
+    s.status,
+    TO_CHAR(s.scheduled_for, 'YYYY-MM-DD HH24:MI') AS scheduled_for,
+    TO_CHAR(s.scheduled_for, 'YYYY-MM-DD"T"HH24:MI') AS scheduled_for_iso,
+    TO_CHAR(s.created_at, 'YYYY-MM-DD HH24:MI') AS created_at,
+    TO_CHAR(s.updated_at, 'YYYY-MM-DD HH24:MI') AS updated_at,
+    TO_CHAR(s.last_attempted_at, 'YYYY-MM-DD HH24:MI') AS last_attempted_at,
+    COALESCE(s.result, '') AS result
+"""
+
+SCHEDULE_SELECT_BASE = f"""
+    SELECT {SCHEDULE_COLUMNS}
+    FROM ai_content_schedules s
+    JOIN ai_content_jobs j ON j.id = s.job_id
+    LEFT JOIN ai_content_profiles p ON p.id = j.profile_id
+"""
+
+SCHEDULE_STATUSES = {"scheduled", "posted", "failed", "canceled"}
+
+
+def format_schedule(row) -> dict:
+    return {
+        "id": row.id,
+        "job_id": row.job_id,
+        "job_title": row.job_title,
+        "job_content_type": row.job_content_type or "",
+        "job_profile_name": row.job_profile_name or "",
+        "job_profile_platform": row.job_profile_platform or "",
+        "platform": row.platform,
+        "status": row.status,
+        "scheduled_for": row.scheduled_for,
+        "scheduled_for_iso": row.scheduled_for_iso,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+        "last_attempted_at": row.last_attempted_at,
+        "result": row.result or "",
+    }
+
+
+def parse_schedule_time(value: str) -> datetime:
+    if not value:
+        raise HTTPException(400, "schedule time required")
+    raw = value.strip()
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(400, "invalid schedule time")
+    if parsed.tzinfo:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def fetch_schedule(conn, schedule_id: int):
+    return conn.execute(text(SCHEDULE_SELECT_BASE + " WHERE s.id=:id"), {"id": schedule_id}).fetchone()
 
 CONTENT_BLUEPRINTS = {
     "social-post": "Craft a set of 3 platform-ready social media posts (TikTok, Instagram Reels, Twitter/X). Each should have a hook, supporting body, and CTA. Include relevant hashtags.",
@@ -495,7 +570,8 @@ def ai_profile_delete(req: Request, profile_id: int):
 def ai_jobs(req: Request, profile_id: Optional[int] = Query(None), limit: int = Query(20, ge=1, le=100)):
     _uid, email, role = require_user(req)
     base_sql = (
-        "SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords, j.brief, j.data_sources, "
+        "SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, COALESCE(p.target_platform,'') AS profile_platform, "
+        "j.title, j.keywords, j.brief, j.data_sources, "
         "j.content_type, j.generated_content, j.status, "
         "TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at, TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at "
         "FROM ai_content_jobs j LEFT JOIN ai_content_profiles p ON p.id=j.profile_id"
@@ -515,7 +591,9 @@ def ai_job_detail(req: Request, job_id: int):
     with engine.begin() as conn:
         row = conn.execute(text(
             """
-            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords,
+            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name,
+                   COALESCE(p.target_platform,'') AS profile_platform,
+                   j.title, j.keywords,
                    j.brief, j.data_sources, j.content_type, j.generated_content, j.status,
                    TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at,
                    TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
@@ -602,7 +680,9 @@ def ai_generate(req: Request, payload: dict):
         ), {"id": job_id, "content": generated, "status": status})
         row = conn.execute(text(
             """
-            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name, j.title, j.keywords,
+            SELECT j.id, j.profile_id, COALESCE(p.name,'') AS profile_name,
+                   COALESCE(p.target_platform,'') AS profile_platform,
+                   j.title, j.keywords,
                    j.brief, j.data_sources, j.content_type, j.generated_content, j.status,
                    TO_CHAR(j.created_at,'YYYY-MM-DD HH24:MI') AS created_at,
                    TO_CHAR(j.updated_at,'YYYY-MM-DD HH24:MI') AS updated_at
@@ -614,6 +694,128 @@ def ai_generate(req: Request, payload: dict):
         raise HTTPException(500, "job retrieval failed")
     audit(email, "ai:generate", {"job_id": job_id, "title": title, "profile": profile_dict.get("name")})
     return {"job": format_job(row), "note": note}
+
+
+@app.get("/ai/schedule")
+def ai_schedule_list(req: Request, status: Optional[str] = Query(None)):
+    _uid, email, role = require_user(req)
+    where = ""
+    params = {}
+    if status:
+        normalized = status.strip().lower()
+        if normalized not in SCHEDULE_STATUSES:
+            raise HTTPException(400, "invalid status filter")
+        where = " WHERE s.status=:status"
+        params["status"] = normalized
+    sql = SCHEDULE_SELECT_BASE + where + " ORDER BY s.scheduled_for ASC, s.id ASC"
+    with engine.begin() as conn:
+        rows = conn.execute(text(sql), params).fetchall()
+    return {"schedules": [format_schedule(r) for r in rows]}
+
+
+@app.post("/ai/schedule")
+def ai_schedule_create(req: Request, payload: dict):
+    uid, email, role = require_user(req)
+    try:
+        job_id = int(payload.get("job_id"))
+    except (TypeError, ValueError):
+        raise HTTPException(400, "job_id required")
+    platform = (payload.get("platform") or "").strip()
+    if not platform:
+        raise HTTPException(400, "platform required")
+    scheduled_for_raw = (payload.get("scheduled_for") or "").strip()
+    scheduled_for = parse_schedule_time(scheduled_for_raw)
+    with engine.begin() as conn:
+        job_row = conn.execute(text("SELECT id FROM ai_content_jobs WHERE id=:id"), {"id": job_id}).fetchone()
+        if not job_row:
+            raise HTTPException(404, "job not found")
+        inserted = conn.execute(text(
+            """
+            INSERT INTO ai_content_schedules(job_id, platform, scheduled_for, status, created_by)
+            VALUES (:job_id, :platform, :scheduled_for, 'scheduled', :created_by)
+            RETURNING id
+            """
+        ), {
+            "job_id": job_id,
+            "platform": platform,
+            "scheduled_for": scheduled_for,
+            "created_by": uid,
+        }).fetchone()
+        schedule_row = fetch_schedule(conn, inserted.id)
+    if not schedule_row:
+        raise HTTPException(500, "schedule create failed")
+    audit(email, "ai:schedule:create", {"job_id": job_id, "schedule_id": schedule_row.id, "platform": platform})
+    return {"schedule": format_schedule(schedule_row)}
+
+
+@app.put("/ai/schedule/{schedule_id}")
+def ai_schedule_update(req: Request, schedule_id: int, payload: dict):
+    uid, email, role = require_user(req)
+    platform_raw = payload.get("platform") if isinstance(payload, dict) else None
+    scheduled_for_raw = payload.get("scheduled_for") if isinstance(payload, dict) else None
+    updates = []
+    params = {"id": schedule_id}
+    with engine.begin() as conn:
+        existing = conn.execute(text("SELECT status FROM ai_content_schedules WHERE id=:id"), {"id": schedule_id}).fetchone()
+        if not existing:
+            raise HTTPException(404, "schedule not found")
+        new_status = existing.status
+        if platform_raw is not None:
+            platform = platform_raw.strip()
+            if not platform:
+                raise HTTPException(400, "platform cannot be empty")
+            updates.append("platform=:platform")
+            params["platform"] = platform
+        if scheduled_for_raw is not None:
+            parsed_time = parse_schedule_time(str(scheduled_for_raw))
+            updates.append("scheduled_for=:scheduled_for")
+            params["scheduled_for"] = parsed_time
+            new_status = "scheduled"
+        if new_status != existing.status:
+            updates.append("status=:status")
+            params["status"] = new_status
+        if not updates:
+            raise HTTPException(400, "no changes provided")
+        updates.append("updated_at=NOW()")
+        sql = "UPDATE ai_content_schedules SET " + ", ".join(updates) + " WHERE id=:id"
+        res = conn.execute(text(sql), params)
+        if res.rowcount == 0:
+            raise HTTPException(404, "schedule not found")
+        schedule_row = fetch_schedule(conn, schedule_id)
+    audit(email, "ai:schedule:update", {"schedule_id": schedule_id})
+    return {"schedule": format_schedule(schedule_row)}
+
+
+@app.post("/ai/schedule/{schedule_id}/cancel")
+def ai_schedule_cancel(req: Request, schedule_id: int):
+    uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        res = conn.execute(text(
+            "UPDATE ai_content_schedules SET status='canceled', updated_at=NOW() WHERE id=:id"
+        ), {"id": schedule_id})
+        if res.rowcount == 0:
+            raise HTTPException(404, "schedule not found")
+        schedule_row = fetch_schedule(conn, schedule_id)
+    audit(email, "ai:schedule:cancel", {"schedule_id": schedule_id})
+    return {"schedule": format_schedule(schedule_row)}
+
+
+@app.post("/ai/schedule/{schedule_id}/retry")
+def ai_schedule_retry(req: Request, schedule_id: int):
+    uid, email, role = require_user(req)
+    with engine.begin() as conn:
+        res = conn.execute(text(
+            """
+            UPDATE ai_content_schedules
+            SET status='scheduled', last_attempted_at=NULL, updated_at=NOW()
+            WHERE id=:id
+            """
+        ), {"id": schedule_id})
+        if res.rowcount == 0:
+            raise HTTPException(404, "schedule not found")
+        schedule_row = fetch_schedule(conn, schedule_id)
+    audit(email, "ai:schedule:retry", {"schedule_id": schedule_id})
+    return {"schedule": format_schedule(schedule_row)}
 
 # ---------- Proxmox helpers ----------
 def pve_headers():

--- a/backend/app/templates/ai_content.html
+++ b/backend/app/templates/ai_content.html
@@ -33,6 +33,30 @@
     .small{font-size:0.8rem;color:#94a3b8}
     .actions button{margin-right:8px}
     .inline{display:inline-flex;gap:8px;align-items:center}
+    .schedule-grid{display:grid;gap:16px;margin-top:12px}
+    .schedule-platform{background:#0f172a;border:1px solid #1f2a3a;border-radius:12px;padding:14px}
+    .schedule-platform header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+    .schedule-statuses{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .schedule-status-group{background:#0b1220;border-radius:12px;padding:12px;border:1px solid #1f2a3a}
+    .schedule-status-title{font-size:0.8rem;text-transform:uppercase;color:#94a3b8;margin-bottom:8px}
+    .schedule-entry{background:#0f172a;border-radius:10px;padding:10px;margin-bottom:8px;border:1px solid #1f2a3a}
+    .schedule-entry strong{display:block;margin-bottom:4px}
+    .schedule-entry .actions{margin-top:8px}
+    .schedule-entry .actions button{margin-right:6px;margin-top:0}
+    .status.badge{padding:2px 8px;border-radius:999px;font-size:0.75rem;background:#1e293b}
+    .status.scheduled{color:#60a5fa}
+    .status.posted{color:#4ade80}
+    .status.failed{color:#f87171}
+    .status.canceled{color:#94a3b8}
+    .modal-backdrop{position:fixed;inset:0;background:rgba(15,23,42,0.75);display:none;z-index:40}
+    .modal-backdrop.active{display:block}
+    .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;z-index:50;padding:20px}
+    .modal.active{display:flex}
+    .modal .modal-content{background:#111923;border-radius:14px;padding:20px;width:100%;max-width:420px;box-shadow:0 20px 60px rgba(8,15,25,0.6)}
+    .modal .modal-content h3{margin-bottom:12px}
+    .hidden{display:none}
+    .schedule-board-header{display:flex;justify-content:space-between;align-items:center}
+    .schedule-board-actions button{margin-top:0;margin-left:8px}
   </style>
 </head>
 <body>
@@ -111,13 +135,103 @@
       <div id="jobsEmpty" class="muted" style="margin-top:12px;display:none">No generations yet. Launch one above.</div>
       <div id="jobsList"></div>
     </section>
+
+    <section class="panel" style="margin-top:18px">
+      <div class="schedule-board-header">
+        <h3>4 · Publishing schedule</h3>
+        <div class="schedule-board-actions">
+          <button type="button" class="secondary" onclick="refreshSchedules()">Refresh</button>
+        </div>
+      </div>
+      <div class="small" style="margin-top:4px">Track upcoming drops grouped by platform and delivery status.</div>
+      <div id="scheduleEmpty" class="muted" style="margin-top:12px;display:none">No scheduled deliveries yet.</div>
+      <div id="scheduleBoard" class="schedule-grid"></div>
+    </section>
+  </div>
+  <div id="scheduleBackdrop" class="modal-backdrop"></div>
+  <div id="scheduleModal" class="modal">
+    <div class="modal-content">
+      <h3 id="scheduleModalTitle">Schedule delivery</h3>
+      <form id="scheduleForm">
+        <input type="hidden" id="schedule_job_id">
+        <input type="hidden" id="schedule_edit_id">
+        <label for="schedule_platform">Platform</label>
+        <input id="schedule_platform" placeholder="TikTok · Instagram" required>
+        <label for="schedule_time">Run at</label>
+        <input id="schedule_time" type="datetime-local" required>
+        <div class="flex">
+          <button type="submit">Save</button>
+          <button type="button" class="secondary" onclick="closeScheduleModal()">Cancel</button>
+        </div>
+        <div class="small muted" id="schedule_form_note" style="margin-top:8px"></div>
+      </form>
+    </div>
   </div>
   <script>
     const esc = (value) => String(value ?? '').replace(/[&<>]/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[ch]));
     let profiles = [];
     let jobs = [];
+    let schedules = [];
     const profileSelect = document.getElementById('gen_profile');
     profileSelect.innerHTML = '<option value="">(loading profiles...)</option>';
+    const scheduleModal = document.getElementById('scheduleModal');
+    const scheduleBackdrop = document.getElementById('scheduleBackdrop');
+    const scheduleForm = document.getElementById('scheduleForm');
+    const scheduleStatusLabels = {
+      scheduled: 'Scheduled',
+      posted: 'Posted',
+      failed: 'Failed',
+      canceled: 'Canceled',
+    };
+
+    function derivePrimaryPlatform(raw) {
+      if (!raw) return '';
+      const pieces = String(raw)
+        .split(/[·,\\/|]/)
+        .map((part) => part.trim())
+        .filter(Boolean);
+      return pieces[0] || '';
+    }
+
+    function formatDisplayTime(iso) {
+      if (!iso) return '';
+      let normalized = iso;
+      if (normalized.length === 16) {
+        normalized = `${normalized}:00`;
+      }
+      const dt = new Date(normalized);
+      if (Number.isNaN(dt.getTime())) {
+        return iso.replace('T', ' ');
+      }
+      return dt.toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+
+    function updateJobScheduleSummary(el, jobId) {
+      const jobSchedules = schedules.filter((item) => Number(item.job_id) === Number(jobId));
+      if (!jobSchedules.length) {
+        el.textContent = 'No scheduled deliveries yet.';
+        return;
+      }
+      const counts = {};
+      jobSchedules.forEach((item) => {
+        const status = item.status || 'scheduled';
+        counts[status] = (counts[status] || 0) + 1;
+      });
+      const parts = Object.entries(counts).map(([status, count]) => `${scheduleStatusLabels[status] || status}: ${count}`);
+      const upcoming = jobSchedules
+        .filter((item) => item.status === 'scheduled')
+        .sort((a, b) => (a.scheduled_for_iso || '').localeCompare(b.scheduled_for_iso || ''))[0];
+      let msg = `Schedules → ${parts.join(', ')}`;
+      if (upcoming) {
+        msg += ` · Next drop ${formatDisplayTime(upcoming.scheduled_for_iso)}`;
+      }
+      el.textContent = msg;
+    }
 
     async function fetchJSON(url, options) {
       const res = await fetch(url, options);
@@ -284,6 +398,22 @@
       }
     }
 
+    async function refreshSchedules() {
+      try {
+        const data = await fetchJSON('/ai/schedule');
+        schedules = data.schedules || [];
+        renderScheduleBoard();
+        renderJobs();
+      } catch (err) {
+        console.error('Schedules load failed', err);
+        const empty = document.getElementById('scheduleEmpty');
+        if (empty) {
+          empty.style.display = 'block';
+          empty.textContent = 'Failed to load schedules: ' + err.message;
+        }
+      }
+    }
+
     function renderJobs() {
       const wrap = document.getElementById('jobsList');
       wrap.innerHTML = '';
@@ -296,6 +426,8 @@
       jobs.forEach((j) => {
         const div = document.createElement('div');
         div.className = 'job';
+        const primaryPlatform = derivePrimaryPlatform(j.profile_platform);
+        const buttonLabel = primaryPlatform ? `Schedule for ${primaryPlatform}` : 'Schedule post';
         div.innerHTML = `
           <div class="inline">
             <strong>${esc(j.title)}</strong>
@@ -305,17 +437,265 @@
           <div class="small">Ran ${esc(j.updated_at || j.created_at || '')}</div>
           <div class="status ${esc(j.status)}">Status: ${esc(j.status)}</div>
           <div class="small" style="margin-top:8px">Keywords: ${esc(j.keywords || '—')}</div>
+          <div class="small job-schedule-summary" style="margin-top:8px"></div>
+          <div class="actions" style="margin-top:10px">
+            <button type="button" class="schedule-trigger">${esc(buttonLabel)}</button>
+          </div>
           <details style="margin-top:10px">
             <summary class="small">View output</summary>
             <pre>${esc(j.generated_content || '')}</pre>
           </details>
         `;
         wrap.appendChild(div);
+        const summaryEl = div.querySelector('.job-schedule-summary');
+        if (summaryEl) {
+          updateJobScheduleSummary(summaryEl, j.id);
+        }
+        const trigger = div.querySelector('.schedule-trigger');
+        if (trigger) {
+          trigger.addEventListener('click', () => openScheduleModal(j.id, primaryPlatform));
+        }
       });
+    }
+
+    function renderScheduleBoard() {
+      const board = document.getElementById('scheduleBoard');
+      const empty = document.getElementById('scheduleEmpty');
+      if (!board || !empty) return;
+      board.innerHTML = '';
+      if (!schedules.length) {
+        empty.style.display = 'block';
+        return;
+      }
+      empty.style.display = 'none';
+      const groups = {};
+      schedules.forEach((entry) => {
+        const platform = entry.platform || 'Unassigned';
+        if (!groups[platform]) {
+          groups[platform] = [];
+        }
+        groups[platform].push(entry);
+      });
+      const statusOrder = ['scheduled', 'posted', 'failed', 'canceled'];
+      Object.keys(groups)
+        .sort((a, b) => a.localeCompare(b))
+        .forEach((platform) => {
+          const entries = groups[platform];
+          const container = document.createElement('div');
+          container.className = 'schedule-platform';
+          const header = document.createElement('header');
+          const left = document.createElement('div');
+          const title = document.createElement('strong');
+          title.textContent = platform;
+          const meta = document.createElement('div');
+          meta.className = 'small';
+          meta.textContent = `${entries.length} total drops`;
+          left.appendChild(title);
+          left.appendChild(meta);
+          header.appendChild(left);
+          const right = document.createElement('div');
+          right.className = 'small';
+          const upcoming = entries
+            .filter((entry) => entry.status === 'scheduled')
+            .sort((a, b) => (a.scheduled_for_iso || '').localeCompare(b.scheduled_for_iso || ''))[0];
+          right.textContent = upcoming ? `Next: ${formatDisplayTime(upcoming.scheduled_for_iso)}` : 'No upcoming runs';
+          header.appendChild(right);
+          container.appendChild(header);
+          const statusWrap = document.createElement('div');
+          statusWrap.className = 'schedule-statuses';
+          statusOrder.forEach((status) => {
+            const subset = entries.filter((entry) => entry.status === status);
+            if (!subset.length) return;
+            const group = document.createElement('div');
+            group.className = 'schedule-status-group';
+            const groupTitle = document.createElement('div');
+            groupTitle.className = 'schedule-status-title';
+            groupTitle.textContent = `${scheduleStatusLabels[status] || status} · ${subset.length}`;
+            group.appendChild(groupTitle);
+            subset
+              .slice()
+              .sort((a, b) => (a.scheduled_for_iso || '').localeCompare(b.scheduled_for_iso || ''))
+              .forEach((entry) => {
+                const entryDiv = document.createElement('div');
+                entryDiv.className = 'schedule-entry';
+                const titleRow = document.createElement('div');
+                titleRow.className = 'inline';
+                const name = document.createElement('strong');
+                name.textContent = entry.job_title || `Job ${entry.job_id}`;
+                const badge = document.createElement('span');
+                badge.className = `status badge ${entry.status}`;
+                badge.textContent = scheduleStatusLabels[entry.status] || entry.status;
+                titleRow.appendChild(name);
+                titleRow.appendChild(badge);
+                entryDiv.appendChild(titleRow);
+                const timeLine = document.createElement('div');
+                timeLine.className = 'small';
+                timeLine.textContent = `Runs ${formatDisplayTime(entry.scheduled_for_iso)}`;
+                entryDiv.appendChild(timeLine);
+                const jobLineParts = [];
+                if (entry.job_profile_name) jobLineParts.push(entry.job_profile_name);
+                if (entry.job_content_type) jobLineParts.push(entry.job_content_type);
+                if (jobLineParts.length) {
+                  const jobLine = document.createElement('div');
+                  jobLine.className = 'small';
+                  jobLine.textContent = jobLineParts.join(' • ');
+                  entryDiv.appendChild(jobLine);
+                }
+                if (entry.result && entry.status === 'failed') {
+                  const resultLine = document.createElement('div');
+                  resultLine.className = 'small';
+                  resultLine.textContent = entry.result;
+                  entryDiv.appendChild(resultLine);
+                }
+                const actions = document.createElement('div');
+                actions.className = 'actions';
+                if (['scheduled', 'failed', 'canceled'].includes(entry.status)) {
+                  const reschedBtn = document.createElement('button');
+                  reschedBtn.type = 'button';
+                  reschedBtn.className = 'secondary';
+                  reschedBtn.textContent = 'Reschedule';
+                  reschedBtn.addEventListener('click', () => openScheduleModalForExisting(entry.id));
+                  actions.appendChild(reschedBtn);
+                }
+                if (entry.status === 'scheduled') {
+                  const cancelBtn = document.createElement('button');
+                  cancelBtn.type = 'button';
+                  cancelBtn.className = 'secondary';
+                  cancelBtn.textContent = 'Cancel';
+                  cancelBtn.addEventListener('click', () => cancelSchedule(entry.id));
+                  actions.appendChild(cancelBtn);
+                }
+                if (entry.status === 'failed') {
+                  const retryBtn = document.createElement('button');
+                  retryBtn.type = 'button';
+                  retryBtn.textContent = 'Retry';
+                  retryBtn.addEventListener('click', () => retrySchedule(entry.id));
+                  actions.appendChild(retryBtn);
+                  const cancelBtn = document.createElement('button');
+                  cancelBtn.type = 'button';
+                  cancelBtn.className = 'secondary';
+                  cancelBtn.textContent = 'Cancel';
+                  cancelBtn.addEventListener('click', () => cancelSchedule(entry.id));
+                  actions.appendChild(cancelBtn);
+                }
+                if (entry.status === 'canceled') {
+                  const reactivateBtn = document.createElement('button');
+                  reactivateBtn.type = 'button';
+                  reactivateBtn.textContent = 'Reactivate';
+                  reactivateBtn.addEventListener('click', () => retrySchedule(entry.id));
+                  actions.appendChild(reactivateBtn);
+                }
+                if (actions.children.length) {
+                  entryDiv.appendChild(actions);
+                }
+                group.appendChild(entryDiv);
+              });
+            statusWrap.appendChild(group);
+          });
+          container.appendChild(statusWrap);
+          board.appendChild(container);
+        });
     }
 
     function setStatus(msg) {
       document.getElementById('aiStatus').textContent = msg || '';
+    }
+
+    function openScheduleModal(jobId, defaultPlatform = '', scheduleId = null, scheduledIso = '') {
+      if (!scheduleModal || !scheduleBackdrop) return;
+      const jobField = document.getElementById('schedule_job_id');
+      const editField = document.getElementById('schedule_edit_id');
+      const platformField = document.getElementById('schedule_platform');
+      const timeField = document.getElementById('schedule_time');
+      const note = document.getElementById('schedule_form_note');
+      const title = document.getElementById('scheduleModalTitle');
+      jobField.value = jobId ? String(jobId) : '';
+      editField.value = scheduleId ? String(scheduleId) : '';
+      platformField.value = typeof defaultPlatform === 'string' ? defaultPlatform : '';
+      timeField.value = scheduledIso ? (scheduledIso.length > 16 ? scheduledIso.slice(0, 16) : scheduledIso) : '';
+      note.textContent = scheduleId ? 'Update the drop time or platform, then save.' : 'Choose when and where to publish this job.';
+      title.textContent = scheduleId ? 'Update schedule' : 'Schedule delivery';
+      scheduleBackdrop.classList.add('active');
+      scheduleModal.classList.add('active');
+      setTimeout(() => platformField.focus(), 50);
+    }
+
+    function openScheduleModalForExisting(scheduleId) {
+      const entry = schedules.find((item) => Number(item.id) === Number(scheduleId));
+      if (!entry) return;
+      openScheduleModal(entry.job_id, entry.platform, entry.id, entry.scheduled_for_iso);
+    }
+
+    function closeScheduleModal() {
+      if (!scheduleModal || !scheduleBackdrop) return;
+      scheduleModal.classList.remove('active');
+      scheduleBackdrop.classList.remove('active');
+      if (scheduleForm) {
+        scheduleForm.reset();
+      }
+      document.getElementById('schedule_form_note').textContent = '';
+      document.getElementById('schedule_edit_id').value = '';
+    }
+
+    async function submitScheduleForm(event) {
+      event.preventDefault();
+      const jobField = document.getElementById('schedule_job_id');
+      const editField = document.getElementById('schedule_edit_id');
+      const platformField = document.getElementById('schedule_platform');
+      const timeField = document.getElementById('schedule_time');
+      const note = document.getElementById('schedule_form_note');
+      const platform = platformField.value.trim();
+      const when = timeField.value;
+      const scheduleId = editField.value;
+      if (!platform || !when) {
+        note.textContent = 'Platform and time are required.';
+        return;
+      }
+      note.textContent = 'Saving...';
+      try {
+        if (scheduleId) {
+          await fetchJSON(`/ai/schedule/${scheduleId}`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ platform, scheduled_for: when }),
+          });
+        } else {
+          const jobId = Number(jobField.value);
+          if (!jobId) {
+            note.textContent = 'Missing job reference.';
+            return;
+          }
+          await fetchJSON('/ai/schedule', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ job_id: jobId, platform, scheduled_for: when }),
+          });
+        }
+        closeScheduleModal();
+        refreshSchedules();
+      } catch (err) {
+        console.error('Schedule save failed', err);
+        note.textContent = 'Error: ' + err.message;
+      }
+    }
+
+    async function cancelSchedule(scheduleId) {
+      if (!confirm('Cancel this scheduled delivery?')) return;
+      try {
+        await fetchJSON(`/ai/schedule/${scheduleId}/cancel`, { method: 'POST' });
+        refreshSchedules();
+      } catch (err) {
+        alert('Cancel failed: ' + err.message);
+      }
+    }
+
+    async function retrySchedule(scheduleId) {
+      try {
+        await fetchJSON(`/ai/schedule/${scheduleId}/retry`, { method: 'POST' });
+        refreshSchedules();
+      } catch (err) {
+        alert('Retry failed: ' + err.message);
+      }
     }
 
     function copyOutput() {
@@ -327,11 +707,31 @@
       navigator.clipboard.writeText(text).then(() => setStatus('Copied to clipboard'), (err) => setStatus('Copy failed: ' + err));
     }
 
+    if (scheduleBackdrop) {
+      scheduleBackdrop.addEventListener('click', closeScheduleModal);
+    }
+    if (scheduleModal) {
+      scheduleModal.addEventListener('click', (event) => {
+        if (event.target === scheduleModal) {
+          closeScheduleModal();
+        }
+      });
+    }
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeScheduleModal();
+      }
+    });
+
     document.getElementById('profileForm').addEventListener('submit', saveProfile);
     document.getElementById('generationForm').addEventListener('submit', runGeneration);
+    if (scheduleForm) {
+      scheduleForm.addEventListener('submit', submitScheduleForm);
+    }
 
     loadProfiles();
     refreshJobs();
+    refreshSchedules();
   </script>
 </body>
 </html>

--- a/dashy/conf.yml
+++ b/dashy/conf.yml
@@ -42,6 +42,10 @@ sections:
     widgets:
       - type: iframe
         options: { url: http://backend.liork.cloud/ui/ai-content, height: 760 }
+    items:
+      - title: Content Scheduler
+        url: http://backend.liork.cloud/ui/ai-content#schedule
+        icon: fas fa-calendar-check
 
   - name: Files & Tasks
     icon: fas fa-folder-tree

--- a/docs/money_bots.md
+++ b/docs/money_bots.md
@@ -20,6 +20,11 @@ The Money Bots unit adds an AI-assisted workspace for spinning up social posts, 
 | `/ai/jobs/{id}` | GET | Retrieve job details. |
 | `/ai/jobs/{id}` | DELETE | Delete a job log entry. |
 | `/ai/content` | POST | Trigger a new generation run. |
+| `/ai/schedule` | GET | List scheduled deliveries (optionally filtered by status). |
+| `/ai/schedule` | POST | Create a scheduled drop for a job. |
+| `/ai/schedule/{id}` | PUT | Update the platform or run time for a scheduled drop. |
+| `/ai/schedule/{id}/cancel` | POST | Cancel a scheduled delivery. |
+| `/ai/schedule/{id}/retry` | POST | Retry a failed or canceled delivery. |
 
 ## Environment variables
 
@@ -45,3 +50,11 @@ Outputs are returned in Markdown with a hook, main body, platform captions, visu
 ## Audit trail
 
 Profile changes, job deletions, and content runs are logged to the existing audit table so leadership can review usage.
+
+## Scheduling dashboard
+
+The Money Bots UI includes a **Publishing schedule** panel that groups upcoming
+deliveries by platform and status. Operators can launch the scheduler directly
+from any generated job, then reschedule, cancel, or retry failed drops inline.
+The same API endpoints documented above power external integrations, making it
+easy to plug the automation flow into other calendaring or posting tools.


### PR DESCRIPTION
## Summary
- add an `ai_content_schedules` table plus REST endpoints to create, update, cancel, and retry scheduled drops
- extend the AI content lab UI with a publishing schedule board, modal scheduling workflow, and inline controls
- document the scheduler, expose a quick link in Dashy, and note the workflow in the Money Bots runbook

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68e556a1408083268296c3c805af1e97